### PR TITLE
Updates for Sensu 0.14 and additional RabbitMQ settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ Just use Galaxy:
 `sensu_server_rabbitmq_ssl`|String|Enables SSL connection to RabbitMQ|`"false"`
 `sensu_server_rabbitmq_user`|String|Username to connect to RabbitMQ|`"sensu"`
 `sensu_server_rabbitmq_password`|String|Password to connect to RabbitMQ|`"placeholder"`
-`sensu_server_dashboard_password`|String|Password for the sensu dashboard|`"placeholder"`
+`sensu_server_dashboard_host`|String|The address on which Uchiwa will listen|`"0.0.0.0"`
+`sensu_server_dashboard_port`|String|The port on which Uchiwa will listen|` "3000"`
+`sensu_server_dashboard_user`|String|The username of the Uchiwa dashboard|`"uchiwa"`
+`sensu_server_dashboard_password`|String|The password for the Uchiwa dashboard|`"placeholder"`
+`sensu_server_dashboard_refresh`|Integer|Determines the interval to pull the Sensu APIs, in seconds|`5`
 `sensu_checks`|Complex type|A variable representing the checks configuration. Will be auto converted to JSON|`''`
 `sensu_handlers`|Complex type|A variable representing the handlers configuration. Will be auto converted to JSON|`''`
 `sensu_server_embedded_ruby`|String|Indicate if Sensu should use the embedded Ruby, or the system one|`"true"`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Just use Galaxy:
 `sensu_server_rabbitmq_hostname`|String|Hostname of the RabbitMQ server|`"127.0.0.1"`
 `sensu_server_rabbitmq_user`|String|Username to connect to RabbitMQ|`"sensu"`
 `sensu_server_rabbitmq_password`|String|Password to connect to RabbitMQ|`"placeholder"`
-`sensu_server_dashboard_host`|String|Hostname of the Sensu Dashboard|`"127.0.0.1`"
 `sensu_server_dashboard_password`|String|Password for the sensu dashboard|`"placeholder"`
 `sensu_checks`|Complex type|A variable representing the checks configuration. Will be auto converted to JSON|`''`
 `sensu_handlers`|Complex type|A variable representing the handlers configuration. Will be auto converted to JSON|`''`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Just use Galaxy:
 `sensu_client_subscription_names`|List|List of test to execute on this client| `[test]`
 `sensu_server_redis_host`|String|Hostname of the Redis server|`"127.0.0.1"`
 `sensu_server_api_host`|String|Adress of the Sensu API server|`"127.0.0.1"`
+`sensu_server_rabbitmq_vhost`|String|RabbitMQ virtual host|`"/sensu"`
 `sensu_server_rabbitmq_hostname`|String|Hostname of the RabbitMQ server|`"127.0.0.1"`
+`sensu_server_rabbitmq_port`|Integer|Port of the RabbitMQ server|`5672`
+`sensu_server_rabbitmq_ssl`|String|Enables SSL connection to RabbitMQ|`"false"`
 `sensu_server_rabbitmq_user`|String|Username to connect to RabbitMQ|`"sensu"`
 `sensu_server_rabbitmq_password`|String|Password to connect to RabbitMQ|`"placeholder"`
 `sensu_server_dashboard_password`|String|Password for the sensu dashboard|`"placeholder"`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 # Variable to control the installation
 sensu_install_client: true
 sensu_install_server: true
+sensu_install_uchiwa: true
 
 # Sensu client variable
 sensu_client_hostname          : "localhost"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,5 +26,4 @@ sensu_server_rabbitmq_port    : "5671"
 sensu_server_rabbitmq_password: "placeholder"
 sensu_server_rabbitmq_ssl     : true
 
-sensu_server_dashboard_host    : "127.0.0.1"
 sensu_server_dashboard_password: "placeholder"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,7 @@ sensu_server_rabbitmq_port    : "5672"
 sensu_server_rabbitmq_password: "placeholder"
 sensu_server_rabbitmq_ssl     : false
 
+sensu_server_dashboard_user: "uchiwa"
+sensu_server_dashboard_password: "placeholder"
+sensu_server_dashboard_port: "3000"
+sensu_server_dashboard_refresh: 5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,7 @@ sensu_server_rabbitmq_hostname: "127.0.0.1"
 sensu_server_rabbitmq_user    : "sensu"
 sensu_server_rabbitmq_port    : "5671"
 sensu_server_rabbitmq_password: "placeholder"
+sensu_server_rabbitmq_ssl     : true
 
 sensu_server_dashboard_host    : "127.0.0.1"
 sensu_server_dashboard_password: "placeholder"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,4 +29,4 @@ sensu_server_rabbitmq_ssl     : false
 sensu_server_dashboard_user: "uchiwa"
 sensu_server_dashboard_password: "placeholder"
 sensu_server_dashboard_port: "3000"
-sensu_server_dashboard_refresh: 5
+sensu_server_dashboard_refresh: 5sensu_server_dashboard_refresh: 10000

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,4 +29,4 @@ sensu_server_rabbitmq_ssl     : false
 sensu_server_dashboard_user: "uchiwa"
 sensu_server_dashboard_password: "placeholder"
 sensu_server_dashboard_port: "3000"
-sensu_server_dashboard_refresh: 5sensu_server_dashboard_refresh: 10000
+sensu_server_dashboard_refresh: 10000

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,8 +22,7 @@ sensu_server_embedded_ruby: "true"
 sensu_server_rabbitmq_vhost   : "/sensu"
 sensu_server_rabbitmq_hostname: "127.0.0.1"
 sensu_server_rabbitmq_user    : "sensu"
-sensu_server_rabbitmq_port    : "5671"
+sensu_server_rabbitmq_port    : "5672"
 sensu_server_rabbitmq_password: "placeholder"
-sensu_server_rabbitmq_ssl     : true
+sensu_server_rabbitmq_ssl     : false
 
-sensu_server_dashboard_password: "placeholder"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ sensu_server_api_host: "127.0.0.1"
 
 sensu_server_embedded_ruby: "true"
 
+sensu_server_rabbitmq_vhost   : "/sensu"
 sensu_server_rabbitmq_hostname: "127.0.0.1"
 sensu_server_rabbitmq_user    : "sensu"
 sensu_server_rabbitmq_port    : "5671"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,3 +10,7 @@
 - name: restart sensu client
   service: name=sensu-client state=restarted
   when: sensu_install_client
+
+- name: restart uchiwa service
+  service: name=uchiwa state=restarted
+  when: sensu_install_uchiwa

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -4,7 +4,7 @@
 
 - name: generate /etc/sensu/conf.d/client.json
   template:
-    src=sensu.client.json.j2
+    src=client.json.j2
     dest=/etc/sensu/conf.d/client.json
     owner=sensu
     group=sensu

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -11,6 +11,6 @@
     mode=0640
     backup=yes
   with_items:
-    client
-    checks
+    - client
+    - checks
   notify: restart sensu client

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -2,22 +2,15 @@
 - name: enable sensu-client to survive reboot
   service: name=sensu-client enabled=yes
 
-- name: generate /etc/sensu/conf.d/client.json
+- name: generate config files
   template:
-    src=client.json.j2
-    dest=/etc/sensu/conf.d/client.json
+    src={{ item }}.json.j2
+    dest=/etc/sensu/conf.d/{{ item }}.json
     owner=sensu
     group=sensu
     mode=0640
     backup=yes
+  with_items:
+    client
+    checks
   notify: restart sensu client
-
-- name: copy all the checks files
-  copy:
-    src=files/sensu/plugins/
-    dest=/etc/sensu/plugins/
-    owner=sensu
-    group=sensu
-    mode=0750
-  notify:
-    - restart sensu client

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -29,6 +29,7 @@
     group=sensu
     mode=0750
     state=directory
+  when: {{ sensu_server_rabbitmq_ssl }}
 
 - name: copy the SSL certificate & key
   copy:
@@ -41,6 +42,7 @@
   with_items:
     - client_cert
     - client_key
+  when: {{ sensu_server_rabbitmq_ssl }}
 
 - name: generate rabbitmq.json
   template:

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -29,7 +29,7 @@
     group=sensu
     mode=0750
     state=directory
-  when: "{{ sensu_server_rabbitmq_ssl }}"
+  when: sensu_server_rabbitmq_ssl
 
 - name: copy the SSL certificate & key
   copy:
@@ -42,7 +42,7 @@
   with_items:
     - client_cert
     - client_key
-  when: "{{ sensu_server_rabbitmq_ssl }}"
+  when: sensu_server_rabbitmq_ssl
 
 - name: generate rabbitmq.json
   template:

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -42,14 +42,16 @@
     - client_cert
     - client_key
 
-- name: generate /etc/sensu/config.json
+- name: generate /etc/sensu/conf.d/rabbitmq.json
   template:
-    src=sensu.config.json.j2
-    dest=/etc/sensu/config.json
+    src={{ item }}.json.j2
+    dest=/etc/sensu/conf.d/{{ item }}.json
     owner=sensu
     group=sensu
     mode=0640
     backup=yes
+  with_items:
+    - rabbitmq
   notify:
     - restart sensu server
     - restart sensu client

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -42,16 +42,14 @@
     - client_cert
     - client_key
 
-- name: generate /etc/sensu/conf.d/rabbitmq.json
+- name: generate rabbitmq.json
   template:
-    src={{ item }}.json.j2
-    dest=/etc/sensu/conf.d/{{ item }}.json
+    src=rabbitmq.json.j2
+    dest=/etc/sensu/conf.d/rabbitmq.json
     owner=sensu
     group=sensu
     mode=0640
     backup=yes
-  with_items:
-    - rabbitmq
   notify:
     - restart sensu server
     - restart sensu client

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -29,7 +29,7 @@
     group=sensu
     mode=0750
     state=directory
-  when: {{ sensu_server_rabbitmq_ssl }}
+  when: "{{ sensu_server_rabbitmq_ssl }}"
 
 - name: copy the SSL certificate & key
   copy:
@@ -42,7 +42,7 @@
   with_items:
     - client_cert
     - client_key
-  when: {{ sensu_server_rabbitmq_ssl }}
+  when: "{{ sensu_server_rabbitmq_ssl }}"
 
 - name: generate rabbitmq.json
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,3 +8,6 @@
 
 - include: client.yml
   when: sensu_install_client
+
+- include: uchiwa.yml
+  when: sensu_install_uchiwa

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,8 +6,8 @@
 - include: server.yml
   when: sensu_install_server
 
+- include: uchiwa.yml
+  when: sensu_install_server and sensu_install_uchiwa
+
 - include: client.yml
   when: sensu_install_client
-
-- include: uchiwa.yml
-  when: sensu_install_uchiwa

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -12,7 +12,7 @@
     - api
 
 - name: ensure the patched init script are used
-  command: /usr/sbin/update-rc.d sensu-{{ item }} remove && /usr/sbin/update-rc.d sensu-{{ item }} defaults
+  command: /usr/sbin/update-rc.d -f sensu-{{ item }} remove && /usr/sbin/update-rc.d sensu-{{ item }} defaults
   with_items:
     - server
     - api

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -31,11 +31,10 @@
     group=sensu
     mode=0750
   with_items:
-    - checks
     - handlers
     - redis
     - api
-    
+
   notify:
     - restart sensu server
     - restart sensu client

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -51,5 +51,6 @@
     owner=sensu
     group=sensu
     mode=0750
+  ignore_errors: yes
   notify:
     - restart sensu server

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -34,6 +34,7 @@
     - handlers
     - redis
     - api
+    - settings
 
   notify:
     - restart sensu server

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -23,34 +23,19 @@
     - server
     - api
 
-- name: generate /etc/sensu/conf.d/checks.json
+- name: generate config files
   template:
-    src=checks.json.j2
-    dest=/etc/sensu/conf.d/checks.json
+    src={{ item }}.json.j2
+    dest=/etc/sensu/conf.d/{{ item }}.json
     owner=sensu
     group=sensu
     mode=0750
+  with_items:
+    - checks
+    - handlers
+    - redis
+    - api
+    
   notify:
     - restart sensu server
     - restart sensu client
-
-- name: generate /etc/sensu/conf.d/handlers.json
-  template:
-    src=handlers.json.j2
-    dest=/etc/sensu/conf.d/handlers.json
-    owner=sensu
-    group=sensu
-    mode=0750
-  notify:
-    - restart sensu server
-
-- name: copy the handlers files
-  copy:
-    src=files/sensu/handlers/
-    dest=/etc/sensu/handlers/
-    owner=sensu
-    group=sensu
-    mode=0750
-  ignore_errors: yes
-  notify:
-    - restart sensu server

--- a/tasks/uchiwa.yml
+++ b/tasks/uchiwa.yml
@@ -1,0 +1,10 @@
+- name: create uchiwa config file
+  template:
+    src=uchiwa.json.j2
+    dest=/etc/sensu/conf.d/uchiwa.json
+    owner=sensu
+    group=sensu
+    mode=0640
+    backup=yes
+  notify:
+    - restart uchiwa service

--- a/tasks/uchiwa.yml
+++ b/tasks/uchiwa.yml
@@ -1,3 +1,6 @@
+- name: install uchiwa
+  apt: name=uchiwa state=present
+
 - name: create uchiwa config file
   template:
     src=uchiwa.json.j2

--- a/tasks/uchiwa.yml
+++ b/tasks/uchiwa.yml
@@ -1,7 +1,7 @@
 - name: create uchiwa config file
   template:
     src=uchiwa.json.j2
-    dest=/etc/sensu/conf.d/uchiwa.json
+    dest=/etc/sensu/uchiwa.json
     owner=sensu
     group=sensu
     mode=0640

--- a/templates/api.json.j2
+++ b/templates/api.json.j2
@@ -1,0 +1,8 @@
+{
+  "api": {
+    "host": "localhost",
+    "port": 4567,
+    "user": "{{ sensu_server_api_user }}",
+    "password": "{{ sensu_server_api_password }}"
+  }
+}

--- a/templates/client.json.j2
+++ b/templates/client.json.j2
@@ -1,0 +1,7 @@
+{
+   "client": {
+      "name": "{{ sensu_client_hostname }}",
+      "address": "{{ sensu_client_address }}",
+      "subscriptions": [ "{{ "\",\"".join(sensu_client_subscription_names) }}" ]
+   }
+}

--- a/templates/rabbitmq.json.j2
+++ b/templates/rabbitmq.json.j2
@@ -1,6 +1,6 @@
 {
   "rabbitmq": {
-    {% if sensu_server_rabbitmq_ssl %}
+    {% if sensu_server_rabbitmq_ssl | bool %}
       "ssl": {
         "private_key_file": "/etc/sensu/ssl/client_key.pem",
         "cert_chain_file": "/etc/sensu/ssl/client_cert.pem"

--- a/templates/rabbitmq.json.j2
+++ b/templates/rabbitmq.json.j2
@@ -10,15 +10,4 @@
     "password": "{{sensu_server_rabbitmq_password}}",
     "vhost": "sensu"
   }
-{% if sensu_install_server %}
-  ,
-  "redis": {
-    "host": "{{ sensu_server_redis_host }}",
-    "port": 6379
-  },
-  "api": {
-    "host": "{{ sensu_server_api_host }}",
-    "port": 4567
-  }
-{% endif %}
 }

--- a/templates/rabbitmq.json.j2
+++ b/templates/rabbitmq.json.j2
@@ -1,9 +1,11 @@
 {
   "rabbitmq": {
-    "ssl": {
-      "private_key_file": "/etc/sensu/ssl/client_key.pem",
-      "cert_chain_file": "/etc/sensu/ssl/client_cert.pem"
-    },
+    {% if sensu_server_rabbitmq_ssl %}
+      "ssl": {
+        "private_key_file": "/etc/sensu/ssl/client_key.pem",
+        "cert_chain_file": "/etc/sensu/ssl/client_cert.pem"
+      },
+    {% endif %}
     "port": {{ sensu_server_rabbitmq_port }},
     "host": "{{ sensu_server_rabbitmq_hostname }}",
     "user": "{{ sensu_server_rabbitmq_user }}",

--- a/templates/rabbitmq.json.j2
+++ b/templates/rabbitmq.json.j2
@@ -10,6 +10,6 @@
     "host": "{{ sensu_server_rabbitmq_hostname }}",
     "user": "{{ sensu_server_rabbitmq_user }}",
     "password": "{{sensu_server_rabbitmq_password}}",
-    "vhost": "sensu"
+    "vhost": "{{ sensu_server_rabbitmq_vhost }}"
   }
 }

--- a/templates/redis.json.j2
+++ b/templates/redis.json.j2
@@ -1,0 +1,6 @@
+{
+  "redis": {
+    "host": "localhost",
+    "port": 6379
+  }
+}

--- a/templates/sensu.client.json.j2
+++ b/templates/sensu.client.json.j2
@@ -1,7 +1,0 @@
-{
-   "client": {
-      "name": "{{ sensu_client_hostname }}",
-         "address": "{{ sensu_client_address }}",
-         "subscriptions": [ "{{ "\",\"".join(sensu_client_subscription_names) }}" ]
-   }
-}

--- a/templates/settings.json.j2
+++ b/templates/settings.json.j2
@@ -1,0 +1,1 @@
+{{ sensu_settings | to_nice_json }}

--- a/templates/uchiwa.json.j2
+++ b/templates/uchiwa.json.j2
@@ -12,10 +12,10 @@
     }
   ],
   "uchiwa": {
-    "user": "admin",
-    "pass": "dev",
-    "port": 3000,
-    "stats": 10,
-    "refresh": 10000
+    "host": "{{ sensu_server_dashboard_host }}",
+    "port": "{{ sensu_server_dashboard_port }}",
+    "user": "{{ sensu_server_dashboard_user }}",
+    "pass": "{{ sensu_server_dashboard_password }}",
+    "refresh": "{{ sensu_server_dashboard_refresh }}"
   }
 }

--- a/templates/uchiwa.json.j2
+++ b/templates/uchiwa.json.j2
@@ -3,8 +3,8 @@
     {
       "name": "Sensu",
       "host": "{{ sensu_server_api_host }}",
-      "ssl": false,
-      "port": {{sensu_server_api_port }},
+      "ssl": {{ sensu_server_rabbitmq_ssl }},
+      "port": {{ sensu_server_api_port }},
       "user": "{{ sensu_server_api_user }}",
       "pass": "{{ sensu_server_api_password }}",
       "path": "",

--- a/templates/uchiwa.json.j2
+++ b/templates/uchiwa.json.j2
@@ -1,0 +1,21 @@
+{
+  "sensu": [
+    {
+      "name": "Sensu",
+      "host": "{{ sensu_server_api_host }}",
+      "ssl": false,
+      "port": {{sensu_server_api_port }},
+      "user": "{{ sensu_server_api_user }}",
+      "pass": "{{ sensu_server_api_password }}",
+      "path": "",
+      "timeout": 5000
+    }
+  ],
+  "uchiwa": {
+    "user": "admin",
+    "pass": "dev",
+    "port": 3000,
+    "stats": 10,
+    "refresh": 10000
+  }
+}

--- a/templates/uchiwa.json.j2
+++ b/templates/uchiwa.json.j2
@@ -13,9 +13,9 @@
   ],
   "uchiwa": {
     "host": "{{ sensu_server_dashboard_host }}",
-    "port": "{{ sensu_server_dashboard_port }}",
+    "port": {{ sensu_server_dashboard_port }},
     "user": "{{ sensu_server_dashboard_user }}",
     "pass": "{{ sensu_server_dashboard_password }}",
-    "refresh": "{{ sensu_server_dashboard_refresh }}"
+    "refresh": {{ sensu_server_dashboard_refresh }}
   }
 }

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -25,7 +25,11 @@ sensu_server_rabbitmq_ssl: false
 sensu_server_rabbitmq_user    : "sensu"
 sensu_server_rabbitmq_password: "placeholder"
 
+sensu_server_dashboard_host: "0.0.0.0"
+sensu_server_dashboard_port: "3000"
+sensu_server_dashboard_user: "uchiwa"
 sensu_server_dashboard_password: "placeholder"
+sensu_server_dashboard_refresh: 5
 
 # Dummy sensu_checks
 sensu_checks:

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -23,7 +23,6 @@ sensu_server_rabbitmq_hostname: '192.168.60.2'
 sensu_server_rabbitmq_user    : "sensu"
 sensu_server_rabbitmq_password: "placeholder"
 
-sensu_server_dashboard_host    : "127.0.0.1"
 sensu_server_dashboard_password: "placeholder"
 
 # Dummy sensu_checks
@@ -40,4 +39,4 @@ sensu_handlers:
   test_handler:
     type   : pipe
     command: "echo"
- 
+

--- a/vars/test.yml
+++ b/vars/test.yml
@@ -20,6 +20,8 @@ sensu_server_api_host: "127.0.0.1"
 sensu_server_embedded_ruby: "true"
 
 sensu_server_rabbitmq_hostname: '192.168.60.2'
+sensu_server_rabbitmq_port: 5672
+sensu_server_rabbitmq_ssl: false
 sensu_server_rabbitmq_user    : "sensu"
 sensu_server_rabbitmq_password: "placeholder"
 


### PR DESCRIPTION
This pull request includes the following changes:

1. Creates separate json config files from templates which was changed after Sensu 0.11.
1. Adds ability to enable/disable use of SSL with RabbitMQ: `sensu_server_rabbitmq_ssl`
1. Adds ability to specify RabbitMQ vhost: `sensu_server_rabbitmq_vhost`
1. Fixes an error that can occur with init script