### PR TITLE
add ability to specify owner and group

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Just use Galaxy:
 |----|----|-----------|-------|
 `sensu_install_client`|Boolean|Determine if we need to install the client part|`true`
 `sensu_install_server`|Boolean|Determine if we need to install the server part|`true`
+`sensu_install_owner`|String|Set owner of installed files|`true`
+`sensu_install_group`|String|Set group of installed files|`true`
 `sensu_client_hostname`|String|Hostname of this client|`"localhost"`
 `sensu_client_address`|String|Address of this client|`"127.0.0.1"`
 `sensu_client_subscription_names`|List|List of test to execute on this client| `[test]`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,9 @@
 sensu_install_client: true
 sensu_install_server: true
 
+sensu_install_owner: sensu
+sensu_install_group: sensu
+
 # Sensu client variable
 sensu_client_hostname          : "localhost"
 sensu_client_address           : "127.0.0.1"

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -6,8 +6,8 @@
   template:
     src=sensu.client.json.j2
     dest=/etc/sensu/conf.d/client.json
-    owner=sensu
-    group=sensu
+    owner="{{ sensu_install_owner }}"
+    group="{{ sensu_install_group }}"
     mode=0640
     backup=yes
   notify: restart sensu client
@@ -16,8 +16,8 @@
   copy:
     src=files/sensu/plugins/
     dest=/etc/sensu/plugins/
-    owner=sensu
-    group=sensu
+    owner="{{ sensu_install_owner }}"
+    group="{{ sensu_install_group }}"
     mode=0750
   notify:
     - restart sensu client

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -25,8 +25,8 @@
 - name: create the SSL directory
   file:
     path=/etc/sensu/ssl
-    owner=sensu
-    group=sensu
+    owner="{{ sensu_install_owner }}"
+    group="{{ sensu_install_group }}"
     mode=0750
     state=directory
 
@@ -34,8 +34,8 @@
   copy:
     src=files/sensu_{{ item }}.pem
     dest=/etc/sensu/ssl/{{ item }}.pem
-    owner=sensu
-    group=sensu
+    owner="{{ sensu_install_owner }}"
+    group="{{ sensu_install_group }}"
     mode=0640
     backup=yes
   with_items:
@@ -46,8 +46,8 @@
   template:
     src=sensu.config.json.j2
     dest=/etc/sensu/config.json
-    owner=sensu
-    group=sensu
+    owner="{{ sensu_install_owner }}"
+    group="{{ sensu_install_group }}"
     mode=0640
     backup=yes
   notify:

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -27,8 +27,8 @@
   template:
     src=checks.json.j2
     dest=/etc/sensu/conf.d/checks.json
-    owner=sensu
-    group=sensu
+    owner="{{ sensu_install_owner }}"
+    group="{{ sensu_install_group }}"
     mode=0750
   notify:
     - restart sensu server
@@ -38,8 +38,8 @@
   template:
     src=handlers.json.j2
     dest=/etc/sensu/conf.d/handlers.json
-    owner=sensu
-    group=sensu
+    owner="{{ sensu_install_owner }}"
+    group="{{ sensu_install_group }}"
     mode=0750
   notify:
     - restart sensu server
@@ -48,8 +48,8 @@
   copy:
     src=files/sensu/handlers/
     dest=/etc/sensu/handlers/
-    owner=sensu
-    group=sensu
+    owner="{{ sensu_install_owner }}"
+    group="{{ sensu_install_group }}"
     mode=0750
   notify:
     - restart sensu server


### PR DESCRIPTION
With the addition of `USER=<some user>` in `/etc/default/sensu`, this allows sensu to be run as a different user.
