### PR TITLE
CentOS 7 support and custom configuration properties for sensu client

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ not have to be on the same host as Sensu thought.
 
 ## Supported system
 
-Currently only Debian Wheezie & Jessie amd64 are supported and tested. Patch
-welcome to support other OS.
+Currently only Debian Wheezie & Jessie amd64 and CentOS 7 x86_64 are supported and tested.
+Patch welcome to support other OS.
 
 ## Installation
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ sensu_client_hostname          : "localhost"
 sensu_client_address           : "127.0.0.1"
 sensu_client_subscription_names:
   - test
+sensu_client_custom_values: {}
 
 # Sensu Server variable
 sensu_server_redis_host: "127.0.0.1"

--- a/files/sensu.repo
+++ b/files/sensu.repo
@@ -1,0 +1,5 @@
+[sensu]
+name=sensu-main
+baseurl=http://repos.sensuapp.org/yum/el/6/$basearch/
+gpgcheck=0
+enabled=1

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -1,20 +1,9 @@
 ---
-- name: add the official Sensu repository's key
-  apt_key: url=http://repos.sensuapp.org/apt/pubkey.gpg state=present
+- include: common_debian.yml
+  when: ansible_distribution == 'Debian'
 
-- name: add the official Sensu repository
-  copy:
-    src=sensu-server.list
-    dest=/etc/apt/sources.list.d/
-    backup=yes
-  register: aptrepo
-
-- name: refresh apt cache
-  apt: update_cache=yes
-  when: aptrepo.changed
-
-- name: install sensu
-  apt: name=sensu state=present
+- include: common_centos.yml
+  when: ansible_distribution == 'CentOS'
 
 - name: set which Ruby to use
   lineinfile:

--- a/tasks/common_centos.yml
+++ b/tasks/common_centos.yml
@@ -1,0 +1,8 @@
+---
+- name: add the official Sensu Yum repository
+  copy: src=sensu.repo
+        dest=/etc/yum.repos.d/sensu.repo
+        backup=yes
+
+- name: install sensu
+  yum: name=sensu state=present

--- a/tasks/common_debian.yml
+++ b/tasks/common_debian.yml
@@ -1,0 +1,17 @@
+---
+- name: add the official Sensu APT repository's key
+  apt_key: url=http://repos.sensuapp.org/apt/pubkey.gpg state=present
+
+- name: add the official Sensu APT repository
+  copy:
+    src=sensu-server.list
+    dest=/etc/apt/sources.list.d/
+    backup=yes
+  register: aptrepo
+
+- name: refresh apt cache
+  apt: update_cache=yes
+  when: aptrepo.changed
+
+- name: install sensu
+  apt: name=sensu state=present

--- a/templates/sensu.client.json.j2
+++ b/templates/sensu.client.json.j2
@@ -1,7 +1,10 @@
 {
-   "client": {
-      "name": "{{ sensu_client_hostname }}",
-         "address": "{{ sensu_client_address }}",
-         "subscriptions": [ "{{ "\",\"".join(sensu_client_subscription_names) }}" ]
-   }
+  "client": {
+    "name": "{{ sensu_client_hostname }}",
+    "address": "{{ sensu_client_address }}",
+    "subscriptions": [ "{{ "\",\"".join(sensu_client_subscription_names) }}" ]
+    {% for key, value in sensu_client_custom_values.items() %}
+      ,"{{ key }}": {{ value | to_nice_json }}
+    {% endfor %}
+  }
 }


### PR DESCRIPTION
Add support to install Sensu on CentOS 7 systems, update README.md to reflect changes. Also allows to specify custom properties to add to a client json configuration file.