### PR TITLE
Force remove init script when reloading with patched version, otherwise operation fails

### DIFF
--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -12,7 +12,7 @@
     - api
 
 - name: ensure the patched init script are used
-  command: /usr/sbin/update-rc.d sensu-{{ item }} remove && /usr/sbin/update-rc.d sensu-{{ item }} defaults
+  command: /usr/sbin/update-rc.d -f sensu-{{ item }} remove && /usr/sbin/update-rc.d sensu-{{ item }} defaults
   with_items:
     - server
     - api


### PR DESCRIPTION
Not sure why the task "ensure the patched init script are used" ever worked. `update-rc.d` will not remove symlinks unless the actual init script is also removed. Using the "-f" option remedies this situation. Otherwise apt package in Ubuntu 14.04 creates the symlinks so the playbook will fail.