### PR TITLE
Remove "equals" (`=`) from multi-line YAML directives.

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -1,25 +1,25 @@
 ---
 - name: copy all the checks files
   copy:
-    src=files/sensu/plugins/
-    dest=/etc/sensu/plugins/
-    owner="{{ sensu_user }}"
-    group="{{ sensu_group }}"
-    mode=0750
+    src: "files/sensu/plugins/"
+    dest: "/etc/sensu/plugins/"
+    owner: "{{ sensu_user }}"
+    group: "{{ sensu_group }}"
+    mode: 0750
 
 - name: generate config files
   template:
-    src=client.json.j2
-    dest=/etc/sensu/conf.d/client.json
-    owner=sensu
-    group=sensu
-    mode=0640
-    backup=yes
+    src: client.json.j2
+    dest: /etc/sensu/conf.d/client.json
+    owner: sensu
+    group: sensu
+    mode: 0640
+    backup: yes
   notify:
     - restart sensu client
 
 - name: enable sensu-client to survive reboot
   service:
-    name=sensu-client
-    enabled=yes
-    state=started
+    name: sensu-client
+    enabled: yes
+    state: started

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -1,12 +1,12 @@
 ---
-- name: add the official Sensu repository's key
+- name: "add the official Sensu repository's key"
   apt_key: url=http://repos.sensuapp.org/apt/pubkey.gpg state=present
 
 - name: add the official Sensu repository
   copy:
-    src=sensu-server.list
-    dest=/etc/apt/sources.list.d/
-    backup=yes
+    src: sensu-server.list
+    dest: /etc/apt/sources.list.d/
+    backup: yes
   register: aptrepo
 
 - name: refresh apt cache
@@ -18,33 +18,33 @@
 
 - name: set which Ruby to use
   lineinfile:
-    dest=/etc/default/sensu
-    regexp=^EMBEDDED_RUBY=
-    line=EMBEDDED_RUBY={{ sensu_embedded_ruby }}
+    dest: /etc/default/sensu
+    regexp: "^EMBEDDED_RUBY="
+    line: "EMBEDDED_RUBY={{ sensu_embedded_ruby }}"
 
 - name: set which user to use
   lineinfile:
-    dest=/etc/default/sensu
-    regexp=^USER=
-    line=USER={{ sensu_user }}
+    dest: /etc/default/sensu
+    regexp: "^USER="
+    line: "USER={{ sensu_user }}"
 
 - name: create the SSL directory
   file:
-    path=/etc/sensu/ssl
-    owner="{{ sensu_user }}"
-    group="{{ sensu_group }}"
-    mode=0750
-    state=directory
+    path: /etc/sensu/ssl
+    owner: "{{ sensu_user }}"
+    group: "{{ sensu_group }}"
+    mode: 0750
+    state: directory
   when: not sensu_server_rabbitmq_insecure
 
 - name: copy the SSL certificate & key
   copy:
-    src={{ sensu_cert_dir }}/{{ item }}
-    dest=/etc/sensu/ssl/{{ item }}
-    owner="{{ sensu_user }}"
-    group="{{ sensu_group }}"
-    mode=0640
-    backup=yes
+    src: "{{ sensu_cert_dir }}/{{ item }}"
+    dest: "/etc/sensu/ssl/{{ item }}"
+    owner: "{{ sensu_user }}"
+    group: "{{ sensu_group }}"
+    mode: 0640
+    backup: yes
   with_items:
     - "{{ sensu_cert_file_name }}"
     - "{{ sensu_key_file_name }}"
@@ -55,12 +55,12 @@
 
 - name: generate rabbitmq.json
   template:
-    src=rabbitmq.json.j2
-    dest=/etc/sensu/conf.d/rabbitmq.json
-    owner=sensu
-    group=sensu
-    mode=0640
-    backup=yes
+    src: rabbitmq.json.j2
+    dest: /etc/sensu/conf.d/rabbitmq.json
+    owner: sensu
+    group: sensu
+    mode: 0640
+    backup: yes
   notify:
     - restart sensu server
     - restart sensu client

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -1,19 +1,21 @@
 ---
 - name: copy the patched init script
   copy:
-    src=sensu-{{ item }}
-    dest=/etc/init.d/
-    owner=root
-    group=root
-    mode=755
-    backup=yes
+    src: "sensu-{{ item }}"
+    dest: /etc/init.d/
+    owner: root
+    group: root
+    mode: 755
+    backup: yes
   with_items:
     - server
     - api
   when: sensu_server_patch_init_scripts
 
 - name: ensure the patched init script are used
-  command: /usr/sbin/update-rc.d -f sensu-{{ item }} remove && /usr/sbin/update-rc.d sensu-{{ item }} defaults
+  command: |
+      /usr/sbin/update-rc.d -f sensu-{{ item }} remove \
+          && /usr/sbin/update-rc.d sensu-{{ item }} defaults
   with_items:
     - server
     - api
@@ -21,39 +23,39 @@
 
 - name: copy the handlers files
   copy:
-    src=files/sensu/handlers/
-    dest=/etc/sensu/handlers/
-    owner=sensu
-    group=sensu
-    mode=0750
+    src: files/sensu/handlers/
+    dest: /etc/sensu/handlers/
+    owner: sensu
+    group: sensu
+    mode: 0750
 
 - name: copy extension files
   copy:
-    src=files/sensu/extensions/
-    dest=/etc/sensu/extensions/
-    owner=sensu
-    group=sensu
-    mode=0750
+    src: files/sensu/extensions/
+    dest: /etc/sensu/extensions/
+    owner: sensu
+    group: sensu
+    mode: 0750
   notify:
     - restart sensu server
 
 - name: copy plugins files
   copy:
-    src=files/sensu/plugins/
-    dest=/etc/sensu/plugins/
-    owner=sensu
-    group=sensu
-    mode=0750
+    src: files/sensu/plugins/
+    dest: /etc/sensu/plugins/
+    owner: sensu
+    group: sensu
+    mode: 0750
   notify:
     - restart sensu server
 
 - name: generate config files
   template:
-    src={{ item }}.json.j2
-    dest=/etc/sensu/conf.d/{{ item }}.json
-    owner=sensu
-    group=sensu
-    mode=0640
+    src: "{{ item }}.json.j2"
+    dest: "/etc/sensu/conf.d/{{ item }}.json"
+    owner: sensu
+    group: sensu
+    mode: 0640
   with_items:
     - handlers
     - redis
@@ -65,9 +67,9 @@
 
 - name: Start sensu-{server,api} and make it survive a reboot
   service:
-    name=sensu-{{ item }}
-    enabled=yes
-    state=started
+    name: "sensu-{{ item }}"
+    enabled: yes
+    state: started
   with_items:
     - server
     - api

--- a/tasks/uchiwa.yml
+++ b/tasks/uchiwa.yml
@@ -4,17 +4,17 @@
 
 - name: create uchiwa config file
   template:
-    src=uchiwa.json.j2
-    dest=/etc/sensu/uchiwa.json
-    owner=sensu
-    group=sensu
-    mode=0640
-    backup=yes
+    src: uchiwa.json.j2
+    dest: /etc/sensu/uchiwa.json
+    owner: sensu
+    group: sensu
+    mode: 0640
+    backup: yes
   notify:
     - restart uchiwa service
 
 - name: Start uchiwa and make it survive a reboot
   service:
-    name=uchiwa
-    enabled=yes
-    state=started
+    name: uchiwa
+    enabled: yes
+    state: started


### PR DESCRIPTION
This prevents syntax highlighting from breaking in Vim. Also stringify
YAML directives with macro definitions (`{{ macro }}`) for clarity.
