### PR TITLE
Fix localhost was hardwired

### DIFF
--- a/templates/redis.json.j2
+++ b/templates/redis.json.j2
@@ -1,6 +1,6 @@
 {
   "redis": {
-    "host": "localhost",
+    "host": "{{ sensu_server_redis_host }}",
     "port": 6379
   }
 }


### PR DESCRIPTION
The 'redis.json.j2' template didn't use the 'sensu_server_redis_host' variable.
