### PR TITLE
Updating repository endpoint as of sensu 0.20

### DIFF
--- a/files/sensu-server.list
+++ b/files/sensu-server.list
@@ -1,2 +1,2 @@
 # Official repository of rabbitmq
-deb http://repos.sensuapp.org/apt sensu main
+deb http://repositories.sensuapp.org/apt sensu main

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -1,6 +1,6 @@
 ---
 - name: add the official Sensu repository's key
-  apt_key: url=http://repos.sensuapp.org/apt/pubkey.gpg state=present
+  apt_key: url=http://repositories.sensuapp.org/apt/pubkey.gpg state=present
 
 - name: add the official Sensu repository
   copy:


### PR DESCRIPTION
As of sensu 0.20 and onwards (latest 0.21), the repository endpoint has changed from `http://repos.sensuapp.org/apt` (reference: [https://sensuapp.org/docs/0.19/install-repositories](url) ) to `http://repositories.sensuapp.org/apt` (reference: [https://sensuapp.org/docs/0.20/install-repositories](url) )
