### PR TITLE
attributes and filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Some plugins depend on installed gems. Required gems can be installed via Sensu'
 `sensu_client_address`|String|Address of this client|`"{{ ansible_default_ipv4.address }}"`
 `sensu_client_subscription_names`|List|List of test to execute on this client| `[test]`
 `sensu_client_attributes`|Object|Additional attributes to set for the client|None
+`sensu_client_attributes_redact`|List|List of attributes to redact for the client|None
 
 ### Server variables
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ files/
  └── sensu_client_key.pem
 ```
 
+Optionally RabbitMQ certificates can be retrieved from an S3 bucket. The system where Ansible runs must have authorization to access this bucket in order to use this feature. See `sensu_rabbitmq_ssl_from_s3`, `sensu_rabbitmq_ssl_s3_bucket`, and `sensu_rabbitmq_ssl_s3_path` Ansible variables for configuration.
+
 Note that you can find a complete set of certificates and keys in
 `vagrant/files/` for **test purpose only**. Be smart, don't use certificates &
 keys publicly available in production! You can also customize this path, see
@@ -115,6 +117,10 @@ please uses the `sensu_settings` variable, that will generate the
 `sensu_cert_dir`|String|Directory to look for the certificates|`files`
 `sensu_cert_file_name`|String|Filename of the client certificate|`sensu_client_cert.pem`
 `sensu_key_file_name`|String|Filename of the client key|`sensu_client_key.pem`
+`sensu_rabbitmq_ssl_from_s3`|Boolean|Determine if we should pull RabbitMQ SSL certificates from an S3 buckets|`false`
+`sensu_rabbitmq_ssl_s3_bucket`|String|Name of the S3 bucket containing RabbitMQ certificates|`""`
+`sensu_rabbitmq_ssl_s3_path`|String|Path within the S3 bucket where RabbitMQ certificates are stored|`""`
+
 
 ### Client variables
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ please uses the `sensu_settings` variable, that will generate the
 `sensu_install_client`|Boolean|Determine if we need to install the client part|`true`
 `sensu_install_server`|Boolean|Determine if we need to install the server part|`true`
 `sensu_install_uchiwa`|Boolean|Determine if we need to install the uchiwa. Will only work in `sensu_install_server` is also true|`true`
+`sensu_file_base`|String|Base path for Ansible file operations. Allows for overriding source path for handlers, extensions, and plugins|`""`
 
 ### General variables
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ If you have custom key/value you want to add to your client configuration,
 please uses the `sensu_settings` variable, that will generate the
 `settings.json` file.
 
+## Gem dependencies
+
+Some plugins depend on installed gems. Required gems can be installed via Sensu's embedded `gem` binary using the `sensu_gems` variable. The variable expects a list of hashes each with a gem `name` and `version` string key.
+
 ## Role Variables
 
 ### Behaviour variables
@@ -121,7 +125,8 @@ please uses the `sensu_settings` variable, that will generate the
 `sensu_rabbitmq_ssl_from_s3`|Boolean|Determine if we should pull RabbitMQ SSL certificates from an S3 buckets|`false`
 `sensu_rabbitmq_ssl_s3_bucket`|String|Name of the S3 bucket containing RabbitMQ certificates|`""`
 `sensu_rabbitmq_ssl_s3_path`|String|Path within the S3 bucket where RabbitMQ certificates are stored|`""`
-
+`sensu_embedded_path`|String|Path to Sensu's embedded directory|`/opt/sensu/embedded/bin`
+`sensu_gems`|Complex type|A variable representing gems to install via Sensu's embedded `gem` binary|`[]`
 
 ### Client variables
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ anymore, but split all the files in the `/etc/sensu/conf.d` folder:
     ├── checks.json
     ├── client.json
     ├── handlers.json
+    ├── filters.json
     ├── rabbitmq.json
     ├── redis.json
     └── settings.json
@@ -118,6 +119,7 @@ Some plugins depend on installed gems. Required gems can be installed via Sensu'
 `sensu_group`|String|the group running sensu|`sensu`
 `sensu_checks`|Complex type|A variable representing the checks configuration. Will be auto converted to JSON|`[]`
 `sensu_handlers`|Complex type|A variable representing the handlers configuration. Will be auto converted to JSON|`[]`
+`sensu_filters`|Complex type|A variable representing the filter configuration. Will be auto converted to JSON|`[]`
 `sensu_embedded_ruby`|String|Indicate if Sensu should use the embedded Ruby, or the system one|`"true"`
 `sensu_cert_dir`|String|Directory to look for the certificates|`files`
 `sensu_cert_file_name`|String|Filename of the client certificate|`sensu_client_cert.pem`
@@ -135,6 +137,7 @@ Some plugins depend on installed gems. Required gems can be installed via Sensu'
 `sensu_client_hostname`|String|Hostname of this client|`"{{ ansible_hostname }}"`
 `sensu_client_address`|String|Address of this client|`"{{ ansible_default_ipv4.address }}"`
 `sensu_client_subscription_names`|List|List of test to execute on this client| `[test]`
+`sensu_client_attributes`|Object|Additional attributes to set for the client|None
 
 ### Server variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,10 @@ sensu_settings: {}
 
 sensu_embedded_ruby: "true"
 
+sensu_embedded_path: "/opt/sensu/embedded/bin"
+
+sensu_gems: []
+
 # Sensu Certificates
 sensu_cert_dir:       files
 sensu_cert_file_name: sensu_client_cert.pem

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,7 +58,6 @@ sensu_server_dashboard_refresh:  5
 
 sensu_checks:   []
 sensu_handlers: []
+sensu_filters: []
 
 sensu_server_patch_init_scripts: true
-
-

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,10 @@ sensu_server_rabbitmq_insecure: false
 sensu_server_rabbitmq_user:     "sensu"
 sensu_server_rabbitmq_password: "placeholder"
 
+sensu_rabbitmq_ssl_from_s3: False
+sensu_rabbitmq_ssl_s3_bucket: ""
+sensu_rabbitmq_ssl_s3_path: ""
+
 sensu_server_dashboard_host:     "0.0.0.0"
 sensu_server_dashboard_port:     "3000"
 sensu_server_dashboard_user:     "uchiwa"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # defaults file for sensu
 
+sensu_file_base: ''
+
 # Variable to control the installation
 sensu_install_client: true
 sensu_install_server: true

--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -1,7 +1,7 @@
 ---
 - name: copy all the checks files
   copy:
-    src=files/sensu/plugins/
+    src="{{ sensu_file_base }}files/sensu/plugins/"
     dest=/etc/sensu/plugins/
     owner="{{ sensu_user }}"
     group="{{ sensu_group }}"

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -37,6 +37,19 @@
     state=directory
   when: not sensu_server_rabbitmq_insecure
 
+- name: pull rabbit ssl client certificates from s3
+  s3:
+    bucket: "{{ sensu_rabbitmq_ssl_s3_bucket }}"
+    object: "{{ sensu_rabbitmq_ssl_s3_path }}/{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: get
+  with_items:
+    - src: "{{ sensu_cert_file_name }}"
+      dest: "/etc/sensu/ssl/{{ sensu_cert_file_name }}"
+    - src: "{{ sensu_key_file_name }}"
+      dest: "/etc/sensu/ssl/{{ sensu_key_file_name }}"
+  when: sensu_rabbitmq_ssl_from_s3
+
 - name: copy the SSL certificate & key
   copy:
     src={{ sensu_cert_dir }}/{{ item }}
@@ -48,7 +61,7 @@
   with_items:
     - "{{ sensu_cert_file_name }}"
     - "{{ sensu_key_file_name }}"
-  when: not sensu_server_rabbitmq_insecure
+  when: not sensu_server_rabbitmq_insecure and not sensu_rabbitmq_ssl_from_s3
   notify:
     - restart sensu server
     - restart sensu client

--- a/tasks/common.yml
+++ b/tasks/common.yml
@@ -22,6 +22,15 @@
     regexp=^EMBEDDED_RUBY=
     line=EMBEDDED_RUBY={{ sensu_embedded_ruby }}
 
+- name: install required gems
+  gem:
+    name="{{ item.name }}"
+    version="{{ item.version }}"
+    state=present
+    executable="{{ sensu_embedded_path }}/gem"
+    user_install=no
+  with_items: "{{ sensu_gems }}"
+
 - name: set which user to use
   lineinfile:
     dest=/etc/default/sensu

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -60,6 +60,7 @@
     - api
     - settings
     - checks
+    - filters
   notify:
     - restart sensu server
 

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -21,7 +21,7 @@
 
 - name: copy the handlers files
   copy:
-    src=files/sensu/handlers/
+    src="{{sensu_file_base}}files/sensu/handlers/"
     dest=/etc/sensu/handlers/
     owner=sensu
     group=sensu
@@ -29,7 +29,7 @@
 
 - name: copy extension files
   copy:
-    src=files/sensu/extensions/
+    src="{{sensu_file_base}}files/sensu/extensions/"
     dest=/etc/sensu/extensions/
     owner=sensu
     group=sensu
@@ -39,7 +39,7 @@
 
 - name: copy plugins files
   copy:
-    src=files/sensu/plugins/
+    src="{{sensu_file_base}}files/sensu/plugins/"
     dest=/etc/sensu/plugins/
     owner=sensu
     group=sensu

--- a/templates/client.json.j2
+++ b/templates/client.json.j2
@@ -2,6 +2,11 @@
    "client": {
       "name": "{{ sensu_client_hostname }}",
       "address": "{{ sensu_client_address }}",
+{% if sensu_client_attributes is defined %}
+{% for item,value in sensu_client_attributes.iteritems() %}
+      "{{ item }}": "{{ value }}",
+{% endfor %}
+{% endif %}
       "subscriptions": [ "{{ "\",\"".join(sensu_client_subscription_names) }}" ]
    }
 }

--- a/templates/client.json.j2
+++ b/templates/client.json.j2
@@ -7,6 +7,9 @@
       "{{ item }}": "{{ value }}",
 {% endfor %}
 {% endif %}
+{% if sensu_client_attributes_redact is defined %}
+      "redact": [ "{{ "\",\"".join(sensu_client_attributes_redact) }}" ],
+{% endif %}
       "subscriptions": [ "{{ "\",\"".join(sensu_client_subscription_names) }}" ]
    }
 }

--- a/templates/client.json.j2
+++ b/templates/client.json.j2
@@ -4,7 +4,7 @@
       "address": "{{ sensu_client_address }}",
 {% if sensu_client_attributes is defined %}
 {% for item,value in sensu_client_attributes.iteritems() %}
-      "{{ item }}": "{{ value }}",
+      "{{ item }}": {{ value | to_json }},
 {% endfor %}
 {% endif %}
       "subscriptions": [ "{{ "\",\"".join(sensu_client_subscription_names) }}" ]

--- a/templates/filters.json.j2
+++ b/templates/filters.json.j2
@@ -1,0 +1,4 @@
+{
+   "filters":
+      {{ sensu_filters | to_nice_json }}
+}

--- a/templates/redis.json.j2
+++ b/templates/redis.json.j2
@@ -1,6 +1,6 @@
 {
   "redis": {
-    "host": "localhost",
+    "host": "{{ sensu_server_redis_host }}",
     "port": 6379
   }
 }

--- a/templates/uchiwa.json.j2
+++ b/templates/uchiwa.json.j2
@@ -13,8 +13,6 @@
   "uchiwa": {
     "host": "{{ sensu_server_dashboard_host }}",
     "port": {{ sensu_server_dashboard_port }},
-    "user": "{{ sensu_server_dashboard_user }}",
-    "pass": "{{ sensu_server_dashboard_password }}",
     "refresh": {{ sensu_server_dashboard_refresh }}
   }
 }


### PR DESCRIPTION
This adds the ability to set attributes on the clients and also filters for controlling handlers. For example The client can set an environment such as production:

``` yaml
sensu_client_attributes:
  environment: "production"
```

Which can then be used to see if pagerduty alarm should be triggered via a filter on the server:

``` yaml
sensu_filters:
  production: {attributes: {client: {environment: production}}, negate: false}

sensu_handlers:
  pagerduty:
    type   : pipe
    command: "/etc/sensu/handlers/pagerduty.rb"
    filters: [ "production" ]
    severities:
      - "critical"
      - "ok"
```
