### PR TITLE
allow redis template to recieve parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,15 @@ please uses the `sensu_settings` variable, that will generate the
 |Name|Type|Description|Default|
 |----|----|-----------|-------|
 `sensu_server_redis_host`|String|Hostname of the Redis server|`"127.0.0.1"`
+`sensu_server_redis_port`|String|Port of the Redis server|`"6379"`
 `sensu_server_api_host`|String|Adress of the Sensu API server|`"127.0.0.1"`
-`sensu_server_api_host`|String|Port of the Sensu API server|`4567`
+`sensu_server_api_port`|String|Port of the Sensu API server|`4567`
 `sensu_server_api_user`|String|User to connect to the api|`"sensu"`
 `sensu_server_api_password`|String|Password for the api user|`"placeholder"`
 `sensu_server_rabbitmq_vhost`|String|RabbitMQ virtual host|`"/sensu"`
 `sensu_server_rabbitmq_hostname`|String|Hostname of the RabbitMQ server|`"127.0.0.1"`
 `sensu_server_rabbitmq_port`|Integer|Port of the RabbitMQ server|`5672`
-`sensu_server_rabbitmq_insecure`|String|Disabel TLS connection to RabbitMQ|`"false"`
+`sensu_server_rabbitmq_insecure`|String|Disable TLS connection to RabbitMQ|`"false"`
 `sensu_server_rabbitmq_user`|String|Username to connect to RabbitMQ|`"sensu"`
 `sensu_server_rabbitmq_password`|String|Password to connect to RabbitMQ|`"placeholder"`
 `sensu_server_dashboard_host`|String|The address on which Uchiwa will listen|`"0.0.0.0"`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,7 @@ sensu_client_subscription_names: [test]
 
 # Sensu Server variable
 sensu_server_redis_host: "127.0.0.1"
+sensu_server_redis_port: 6379
 
 sensu_server_api_host:     "127.0.0.1"
 sensu_server_api_port:     4567

--- a/templates/redis.json.j2
+++ b/templates/redis.json.j2
@@ -1,6 +1,6 @@
 {
   "redis": {
-    "host": "localhost",
-    "port": 6379
+    "host": "{{ sensu_server_redis_host }}",
+    "port": "{{ sensu_server_redis_port }}"
   }
 }


### PR DESCRIPTION
Current redis.conf file has hardcoded values for redis host and port.

I've updated them to reference ansible variables.
