### PR TITLE
Add ability to increase RabbitMQ prefetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Note that you can find a complete set of certificates and keys in
 keys publicly available in production! You can also customize this path, see
 [Roles Variables](#roles-variables).
 
+The prefetch in Sensu defaults to 1, but this can have a negotiation overhead,
+particularly with clusters, so can be changed.
+
 The playbook also expect that you have the following folder organisation for
 Sensu script in your `files/` folder:
 
@@ -139,6 +142,7 @@ please uses the `sensu_settings` variable, that will generate the
 `sensu_server_rabbitmq_insecure`|String|Disabel TLS connection to RabbitMQ|`"false"`
 `sensu_server_rabbitmq_user`|String|Username to connect to RabbitMQ|`"sensu"`
 `sensu_server_rabbitmq_password`|String|Password to connect to RabbitMQ|`"placeholder"`
+`sensu_server_rabbitmq_prefetch`|Integer|Prefetch for RabbitMQ|`1`
 `sensu_server_dashboard_host`|String|The address on which Uchiwa will listen|`"0.0.0.0"`
 `sensu_server_dashboard_port`|String|The port on which Uchiwa will listen|` "3000"`
 `sensu_server_dashboard_user`|String|The username of the Uchiwa dashboard|`"uchiwa"`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ sensu_server_rabbitmq_port:     "5671"
 sensu_server_rabbitmq_insecure: false
 sensu_server_rabbitmq_user:     "sensu"
 sensu_server_rabbitmq_password: "placeholder"
+sensu_server_rabbitmq_prefetch: 1
 
 sensu_server_dashboard_host:     "0.0.0.0"
 sensu_server_dashboard_port:     "3000"

--- a/templates/rabbitmq.json.j2
+++ b/templates/rabbitmq.json.j2
@@ -10,6 +10,7 @@
     "host": "{{ sensu_server_rabbitmq_hostname }}",
     "user": "{{ sensu_server_rabbitmq_user }}",
     "password": "{{sensu_server_rabbitmq_password}}",
+    "prefetch": "{{sensu_server_rabbitmq_prefetch}}",
     "vhost": "{{ sensu_server_rabbitmq_vhost }}"
   }
 }

--- a/vagrant/test-vars.yml
+++ b/vagrant/test-vars.yml
@@ -10,6 +10,7 @@ rabbitmq_users_definitions:
   - vhost:    "{{ sensu_server_rabbitmq_vhost }}"
     user:     "{{ sensu_server_rabbitmq_user }}"
     password: "{{ sensu_server_rabbitmq_password }}"
+    prefetch: "{{ sensu_server_rabbitmq_prefetch }}"
 
 rabbitmq_cacert :     "files/rabbitmq_cacert.pem"
 rabbitmq_server_key:  "files/rabbitmq_server_key.pem"


### PR DESCRIPTION
Sensu defaults to a prefetch of 1 with can add an unwanted negotiation
overhead, particularly when RabbitMQ is clustered.

Here sensu_server_rabbitmq_prefetch can be set, for example to 20
in the group_vars.
